### PR TITLE
Function replacement

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace DateUtils;
 
 /**
@@ -12,9 +11,9 @@ class Module
     /**
      * @param MvcEvent $e
      */
-    public function onBootstrap(MvcEvent $e)
+    public function onBootstrap(MvcEvent $event)
     {
-        $eventManager        = $e->getApplication()->getEventManager();
+        $eventManager = $event->getApplication()->getEventManager();
         $moduleRouteListener = new ModuleRouteListener();
         $moduleRouteListener->attach($eventManager);
 

--- a/src/DateUtils/BankHolidays.php
+++ b/src/DateUtils/BankHolidays.php
@@ -53,34 +53,42 @@ final class BankHolidays
     {
         return $this->bankHolidays;
     }
+
+    /**
+     * @param int  $year
+     * @return int
+     */
+    public static function easterDate($year)
+    {
+        $goldenNumber = $year % 19;
+        $century = (int)($year / 100);
+
+        $lunarAge =
+            (int)($century - (int)($century / 4) -
+            (int)((8*$century+13) / 25) + 19 * $goldenNumber + 15) % 30;
+
+        $fullMoonOffset =
+            (int)$lunarAge -
+            (int)($lunarAge / 28) *
+            (1 - (int)($lunarAge / 28) * (int)(29 / ($lunarAge+ 1)) * ((int)(21 - $goldenNumber) / 11));
+
+        $weekday = ($year + (int)($year/4) + $fullMoonOffset + 2 - $century + (int)($century/4)) % 7;
+
+        $sundayOffset = $fullMoonOffset - $weekday;
+        $month = 3 + (int)(($sundayOffset + 40) / 44);
+        $day = $sundayOffset + 28 - 31 * ((int)($month / 4));
+
+        $easterTimeStamp = mktime(0,0,0, $month, $day, $year);
+
+        return $easterTimeStamp;
+    }
 }
 
+/**
+ * If we do not have the easter_date function defined, we can create our own, it is less efficient than raw C
+ */
 if (false === function_exists('easter_dates')) {
-    function easter_date ($Year) {
-
-        /*
-           G is the Golden Number-1
-          H is 23-Epact (modulo 30)
-         I is the number of days from 21 March to the Paschal full moon
-                    J is the weekday for the Paschal full moon (0=Sunday,
-                         1=Monday, etc.)
-                            L is the number of days from 21 March to the Sunday on or before
-                                 the Paschal full moon (a number between -6 and 28)
-                                    */
-
-
-        $G = $Year % 19;
-        $C = (int)($Year / 100);
-        $H = (int)($C - (int)($C / 4) - (int)((8*$C+13) / 25) + 19*$G + 15) % 30;
-        $I = (int)$H - (int)($H / 28)*(1 - (int)($H / 28)*(int)(29 / ($H + 1))*((int)(21 - $G) / 11));
-        $J = ($Year + (int)($Year/4) + $I + 2 - $C + (int)($C/4)) % 7;
-        $L = $I - $J;
-        $m = 3 + (int)(($L + 40) / 44);
-        $d = $L + 28 - 31 * ((int)($m / 4));
-        $y = $Year;
-        $E = mktime(0,0,0, $m, $d, $y);
-
-        return $E;
-
+    function easter_date ($year) {
+        return BankHolidays::easterDate($year);
     }
 }

--- a/src/DateUtils/BankHolidays.php
+++ b/src/DateUtils/BankHolidays.php
@@ -54,3 +54,33 @@ final class BankHolidays
         return $this->bankHolidays;
     }
 }
+
+if (false === function_exists('easter_dates')) {
+    function easter_date ($Year) {
+
+        /*
+           G is the Golden Number-1
+          H is 23-Epact (modulo 30)
+         I is the number of days from 21 March to the Paschal full moon
+                    J is the weekday for the Paschal full moon (0=Sunday,
+                         1=Monday, etc.)
+                            L is the number of days from 21 March to the Sunday on or before
+                                 the Paschal full moon (a number between -6 and 28)
+                                    */
+
+
+        $G = $Year % 19;
+        $C = (int)($Year / 100);
+        $H = (int)($C - (int)($C / 4) - (int)((8*$C+13) / 25) + 19*$G + 15) % 30;
+        $I = (int)$H - (int)($H / 28)*(1 - (int)($H / 28)*(int)(29 / ($H + 1))*((int)(21 - $G) / 11));
+        $J = ($Year + (int)($Year/4) + $I + 2 - $C + (int)($C/4)) % 7;
+        $L = $I - $J;
+        $m = 3 + (int)(($L + 40) / 44);
+        $d = $L + 28 - 31 * ((int)($m / 4));
+        $y = $Year;
+        $E = mktime(0,0,0, $m, $d, $y);
+
+        return $E;
+
+    }
+}

--- a/src/DateUtils/BankHolidays.php
+++ b/src/DateUtils/BankHolidays.php
@@ -62,6 +62,20 @@ final class BankHolidays
      */
     public static function easterDate($year)
     {
+        //BC Behaviour
+        if (false === is_int($year)) {
+            $errorMessage = sprintf(
+                '%s %s %d',
+                __FUNCTION__,
+                'expects parameter 1 to be long, string given on line',
+                __LINE__
+            );
+
+            trigger_error($errorMessage, E_USER_WARNING);
+
+            return null;
+        }
+
         $goldenNumber = $year % 19;
         $century = (int)($year / 100);
 

--- a/src/DateUtils/BankHolidays.php
+++ b/src/DateUtils/BankHolidays.php
@@ -57,6 +57,8 @@ final class BankHolidays
     /**
      * @param int  $year
      * @return int
+     *
+     * @note see http://en.wikipedia.org/wiki/Computus
      */
     public static function easterDate($year)
     {

--- a/src/DateUtils/BankHolidays.php
+++ b/src/DateUtils/BankHolidays.php
@@ -34,14 +34,14 @@ final class BankHolidays
      */
     public static function calculateFixedHolidays($year)
     {
-        $bankHolidays['newYearsDay']  = date('Y-m-d', strtotime('first day of january ' . $year));
-        $bankHolidays['goodFriday']   = date('Y-m-d', strtotime('previous friday', easter_date($year)));
+        $bankHolidays['newYearsDay'] = date('Y-m-d', strtotime('first day of january ' . $year));
+        $bankHolidays['goodFriday'] = date('Y-m-d', strtotime('previous friday', easter_date($year)));
         $bankHolidays['easterMonday'] = date('Y-m-d', strtotime('next monday', easter_date($year)));
-        $bankHolidays['earlyMay']     = date('Y-m-d', strtotime('first monday of may ' . $year));
-        $bankHolidays['lastMay']      = date('Y-m-d', strtotime('last monday of may ' . $year));
-        $bankHolidays['lateAugust']   = date('Y-m-d', strtotime('last monday of august ' . $year));
-        $bankHolidays['xmasDay']      = date('Y-m-d', strtotime('25 december ' . $year));
-        $bankHolidays['boxingDay']    = date('Y-m-d', strtotime('26 december ' . $year));
+        $bankHolidays['earlyMay'] = date('Y-m-d', strtotime('first monday of may ' . $year));
+        $bankHolidays['lastMay'] = date('Y-m-d', strtotime('last monday of may ' . $year));
+        $bankHolidays['lateAugust'] = date('Y-m-d', strtotime('last monday of august ' . $year));
+        $bankHolidays['xmasDay'] = date('Y-m-d', strtotime('25 december ' . $year));
+        $bankHolidays['boxingDay'] = date('Y-m-d', strtotime('26 december ' . $year));
 
         return $bankHolidays;
     }
@@ -55,7 +55,7 @@ final class BankHolidays
     }
 
     /**
-     * @param int  $year
+     * @param int $year
      * @return int
      *
      * @note see http://en.wikipedia.org/wiki/Computus
@@ -67,20 +67,20 @@ final class BankHolidays
 
         $lunarAge =
             (int)($century - (int)($century / 4) -
-            (int)((8*$century+13) / 25) + 19 * $goldenNumber + 15) % 30;
+                (int)((8 * $century + 13) / 25) + 19 * $goldenNumber + 15) % 30;
 
         $fullMoonOffset =
             (int)$lunarAge -
             (int)($lunarAge / 28) *
-            (1 - (int)($lunarAge / 28) * (int)(29 / ($lunarAge+ 1)) * ((int)(21 - $goldenNumber) / 11));
+            (1 - (int)($lunarAge / 28) * (int)(29 / ($lunarAge + 1)) * ((int)(21 - $goldenNumber) / 11));
 
-        $weekday = ($year + (int)($year/4) + $fullMoonOffset + 2 - $century + (int)($century/4)) % 7;
+        $weekday = ($year + (int)($year / 4) + $fullMoonOffset + 2 - $century + (int)($century / 4)) % 7;
 
         $sundayOffset = $fullMoonOffset - $weekday;
         $month = 3 + (int)(($sundayOffset + 40) / 44);
         $day = $sundayOffset + 28 - 31 * ((int)($month / 4));
 
-        $easterTimeStamp = mktime(0,0,0, $month, $day, $year);
+        $easterTimeStamp = mktime(0, 0, 0, $month, $day, $year);
 
         return $easterTimeStamp;
     }
@@ -90,7 +90,8 @@ final class BankHolidays
  * If we do not have the easter_date function defined, we can create our own, it is less efficient than raw C
  */
 if (false === function_exists('easter_dates')) {
-    function easter_date ($year) {
+    function easter_date($year)
+    {
         return BankHolidays::easterDate($year);
     }
 }

--- a/src/DateUtils/WorkingDays.php
+++ b/src/DateUtils/WorkingDays.php
@@ -15,12 +15,12 @@ class WorkingDays
 
     public function __construct(array $config)
     {
-        $this->config =  $config;
+        $this->config = $config;
     }
 
     /**
      * @param \DateTime $initialDate
-     * @param int       $workingDayOffset
+     * @param int $workingDayOffset
      * @return \DateTime
      * @throws \LogicException
      */
@@ -36,19 +36,19 @@ class WorkingDays
             }
             $dayCounter = 1;
             $currentDay = $initialDate->getTimestamp();
-            $holidays   = $this->getBankHolidays($initialDate->format('Y'));
+            $holidays = $this->getBankHolidays($initialDate->format('Y'));
 
             while ($dayCounter <= $workingDayOffset) {
 
-                $date       = date('Y-m-d', $currentDay);
+                $date = date('Y-m-d', $currentDay);
                 $currentDay = strtotime($date . ' +1 day');
 
                 if (date('Y', $currentDay) != $initialDate->format('Y')) {
                     $holidays = $this->getBankHolidays(date('Y', $currentDay));
                 }
 
-                $date       = date('Y-m-d', $currentDay);
-                $weekday    = date('N', $currentDay);
+                $date = date('Y-m-d', $currentDay);
+                $weekday = date('N', $currentDay);
 
                 if ($weekday < 6 && !in_array($date, $holidays)) {
                     $dayCounter++;
@@ -64,7 +64,7 @@ class WorkingDays
     /**
      * If the offset is greater than 1 day or it forces us to rollover convert it back to an int and call the
      * other function
-     * @param \DateTime     $initialDate
+     * @param \DateTime $initialDate
      * @param \DateInterval $offset
      * @return \DateTime
      */
@@ -74,9 +74,10 @@ class WorkingDays
         $diffDate = \DateTime::createFromFormat('Y-m-d h:i:s', $initialDate->format('Y-m-d 00:00:00'));
         $difference = $targetDate->add($offset)->diff($diffDate);
 
-        if($difference->days >= 1) {
+        if ($difference->days >= 1) {
             return $this->workingDaysFrom($initialDate, $difference->days);
         }
+
         return $initialDate->add($offset);
     }
 
@@ -86,8 +87,8 @@ class WorkingDays
      */
     public function isWorkingDay(\DateTime $targetDate)
     {
-        $holidays   = $this->getBankHolidays($targetDate->format('Y'));
-        $weekDays   = range(1,5);
+        $holidays = $this->getBankHolidays($targetDate->format('Y'));
+        $weekDays = range(1, 5);
 
 
         $workingDay = (
@@ -95,12 +96,12 @@ class WorkingDays
             in_array($targetDate->format('Y-m-d'), $holidays)
         );
 
-        return (bool) !$workingDay;
+        return (bool)!$workingDay;
     }
 
     /**
      * Alias function to calculate days from today, which is the most common usage
-     * @param int        $workingDayOffset
+     * @param int $workingDayOffset
      * @return \DateTime
      */
     public function workingDaysFromToday($workingDayOffset = 1)
@@ -115,8 +116,8 @@ class WorkingDays
      */
     public function workingDaysBetween(\DateTime $startDay, \DateTime $endDay)
     {
-        $holidays   = $this->getBankHolidays($startDay->format('Y'));
-        $weekDays   = range(1,5);
+        $holidays = $this->getBankHolidays($startDay->format('Y'));
+        $weekDays = range(1, 5);
 
         $interval = new \DateInterval('P1D');
         $periods = new \DatePeriod($startDay, $interval, $endDay);
@@ -125,24 +126,30 @@ class WorkingDays
 
         foreach ($periods as $period) {
 
-            if($period->format('Y') != $startDay->format('Y')) {
-                $holidays   = $this->getBankHolidays($period->format('Y'));
+            if ($period->format('Y') != $startDay->format('Y')) {
+                $holidays = $this->getBankHolidays($period->format('Y'));
             }
 
-            if (!in_array($period->format('N'), $weekDays)) continue;
-            if (in_array($period->format('Y-m-d'), $holidays)) continue;
+            if (!in_array($period->format('N'), $weekDays)) {
+                continue;
+            }
+            if (in_array($period->format('Y-m-d'), $holidays)) {
+                continue;
+            }
             $days++;
         }
+
         return $days;
     }
 
     /**
-     * @param  int   $year
+     * @param  int $year
      * @return array
      */
     protected function getBankHolidays($year)
     {
         $bankHolidays = new BankHolidays($this->config, $year);
+
         return $bankHolidays->getBankHolidays();
     }
 }

--- a/test/DateUtilsTest/BankHolidaysTest.php
+++ b/test/DateUtilsTest/BankHolidaysTest.php
@@ -45,6 +45,10 @@ class BankHolidaysTest extends \PHPUnit_Framework_TestCase
 
     public function testEasterDate()
     {
+        $this->assertEquals(BankHolidays::easterDate(2000), mktime(0, 0, 0, 4, 23, 2000));
+        $this->assertEquals(BankHolidays::easterDate(2005), mktime(0, 0, 0, 3, 27, 2005));
+        $this->assertEquals(BankHolidays::easterDate(2010), mktime(0, 0, 0, 4, 4, 2010));
         $this->assertEquals(BankHolidays::easterDate(2015), mktime(0, 0, 0, 4, 5, 2015));
+        $this->assertEquals(BankHolidays::easterDate(2020), mktime(0, 0, 0, 4, 12, 2020));
     }
 }

--- a/test/DateUtilsTest/BankHolidaysTest.php
+++ b/test/DateUtilsTest/BankHolidaysTest.php
@@ -51,4 +51,22 @@ class BankHolidaysTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(BankHolidays::easterDate(2015), mktime(0, 0, 0, 4, 5, 2015));
         $this->assertEquals(BankHolidays::easterDate(2020), mktime(0, 0, 0, 4, 12, 2020));
     }
+
+    public function testEasterDateRaisesWarningWhenANonNumberIsPassed()
+    {
+        $currentClass = $this;
+        $handler = set_error_handler(
+            function($errno, $errstring) use ($currentClass) {
+                $currentClass->assertEquals($errno, E_USER_WARNING);
+                $currentClass->assertEquals(
+                    $errstring,
+                    'easterDate expects parameter 1 to be long, string given on line 71'
+                );
+            }
+        );
+
+        $this->assertNull(BankHolidays::easterDate('invalidNumber'));
+
+        set_error_handler($handler);
+    }
 }

--- a/test/DateUtilsTest/BankHolidaysTest.php
+++ b/test/DateUtilsTest/BankHolidaysTest.php
@@ -42,4 +42,9 @@ class BankHolidaysTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('queensDiamondJubilee', $holidays));
         $this->assertEquals("2012-02-01", $holidays['newYearsDay']);
     }
+
+    public function testEasterDate()
+    {
+        $this->assertEquals(BankHolidays::easterDate(2015), mktime(0, 0, 0, 4, 5, 2015));
+    }
 }


### PR DESCRIPTION
Some versions of PHP and all versions of HVMM do not support the calendar extensions. This replaces our reliance on using the built in easter date function. If it is missing we use our own version
